### PR TITLE
Add np as numpy alias

### DIFF
--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -1,11 +1,14 @@
+import numpy as np
 from scipy import ndimage
-import numpy
 
-def warp_images(from_points, to_points, images, output_region, interpolation_order = 1, approximate_grid=2):
+
+def warp_images(from_points, to_points, images, output_region,
+                interpolation_order=1, approximate_grid=2):
     """Return an array of warped images.
 
-    Define a thin-plate-spline warping transform that warps from the from_points
-    to the to_points, and then warp the given images by that transform.
+    Define a thin-plate-spline warping transform that warps from the
+    from_points to the to_points, and then warp the given images by
+    that transform.
 
     Parameters
     ----------
@@ -23,10 +26,10 @@ def warp_images(from_points, to_points, images, output_region, interpolation_ord
         If value is 1, then use linear interpolation else use
         nearest-neighbor interpolation.
     approximate_grid: int, optional
-        If approximate_grid is greater than 1, say x, then the transform is defined
-        on a grid x times smaller than the output image region. Then the
-        transform is bilinearly interpolated to the larger region. This is fairly
-        accurate for values up to 10 or so.
+        If approximate_grid is greater than 1, say x, then the transform is
+        defined on a grid x times smaller than the output image region.
+        Then the transform is bilinearly interpolated to the larger region.
+        This is fairly accurate for values up to 10 or so.
 
     Returns
     -------
@@ -36,13 +39,15 @@ def warp_images(from_points, to_points, images, output_region, interpolation_ord
     References
     ----------
     .. [1] Bookstein, Fred L. "Principal warps: Thin-plate splines and the
-    decomposition of deformations." IEEE Transactions on pattern analysis and
-    machine intelligence 11.6 (1989): 567-585.
+    decomposition of deformations." IEEE Transactions on pattern analysis
+    and machine intelligence 11.6 (1989): 567-585.
 
     """
+    transform = _make_inverse_warp(
+        from_points, to_points, output_region, approximate_grid)
+    return [ndimage.map_coordinates(np.asarray(image),
+                                    transform, order=interpolation_order) for image in images]
 
-    transform = _make_inverse_warp(from_points, to_points, output_region, approximate_grid)
-    return [ndimage.map_coordinates(numpy.asarray(image), transform, order=interpolation_order) for image in images]
 
 def _make_inverse_warp(from_points, to_points, output_region, approximate_grid):
     x_min, y_min, x_max, y_max = output_region
@@ -50,17 +55,19 @@ def _make_inverse_warp(from_points, to_points, output_region, approximate_grid):
         approximate_grid = 1
     x_steps = (x_max - x_min) // approximate_grid
     y_steps = (y_max - y_min) // approximate_grid
-    x, y = numpy.mgrid[x_min:x_max:x_steps*1j, y_min:y_max:y_steps*1j]
+    x, y = np.mgrid[x_min:x_max:x_steps*1j, y_min:y_max:y_steps*1j]
 
-    # make the reverse transform warping from the to_points to the from_points, because we
-    # do image interpolation in this reverse fashion
+    # make the reverse transform warping from the to_points to the from_points,
+    # because we do image interpolation in this reverse fashion
     transform = _make_warp(to_points, from_points, x, y)
 
     if approximate_grid != 1:
         # linearly interpolate the zoomed transform grid
-        new_x, new_y = numpy.mgrid[x_min:x_max+1, y_min:y_max+1]
-        x_fracs, x_indices = numpy.modf((x_steps-1)*(new_x-x_min)/float(x_max-x_min))
-        y_fracs, y_indices = numpy.modf((y_steps-1)*(new_y-y_min)/float(y_max-y_min))
+        new_x, new_y = np.mgrid[x_min:x_max+1, y_min:y_max+1]
+        x_fracs, x_indices = np.modf(
+            (x_steps-1)*(new_x-x_min)/float(x_max-x_min))
+        y_fracs, y_indices = np.modf(
+            (y_steps-1)*(new_y-y_min)/float(y_max-y_min))
         x_indices = x_indices.astype(int)
         y_indices = y_indices.astype(int)
         x1 = 1 - x_fracs
@@ -71,52 +78,64 @@ def _make_inverse_warp(from_points, to_points, output_region, approximate_grid):
         t01 = transform[0][(x_indices, iy1)]
         t10 = transform[0][(ix1, y_indices)]
         t11 = transform[0][(ix1, iy1)]
-        transform_x = t00*x1*y1 + t01*x1*y_fracs + t10*x_fracs*y1 + t11*x_fracs*y_fracs
+        transform_x = (t00*x1*y1 + t01*x1*y_fracs + t10 *
+                       x_fracs*y1 + t11*x_fracs*y_fracs)
         t00 = transform[1][(x_indices, y_indices)]
         t01 = transform[1][(x_indices, iy1)]
         t10 = transform[1][(ix1, y_indices)]
         t11 = transform[1][(ix1, iy1)]
-        transform_y = t00*x1*y1 + t01*x1*y_fracs + t10*x_fracs*y1 + t11*x_fracs*y_fracs
+        transform_y = (t00*x1*y1 + t01*x1*y_fracs + t10 *
+                       x_fracs*y1 + t11*x_fracs*y_fracs)
         transform = [transform_x, transform_y]
     return transform
 
+
 _small = 1e-100
+
+
 def _U(x):
-    return (x**2) * numpy.where(x<_small, 0, numpy.log(x))
+
+    return (x**2) * np.where(x < _small, 0, np.log(x))
+
 
 def _interpoint_distances(points):
-    xd = numpy.subtract.outer(points[:,0], points[:,0])
-    yd = numpy.subtract.outer(points[:,1], points[:,1])
-    return numpy.sqrt(xd**2 + yd**2)
+    xd = np.subtract.outer(points[:, 0], points[:, 0])
+    yd = np.subtract.outer(points[:, 1], points[:, 1])
+    return np.sqrt(xd**2 + yd**2)
+
 
 def _make_L_matrix(points):
     n = len(points)
     K = _U(_interpoint_distances(points))
-    P = numpy.ones((n, 3))
-    P[:,1:] = points
-    O = numpy.zeros((3, 3))
-    L = numpy.asarray(numpy.bmat([[K, P],[P.transpose(), O]]))
+    P = np.ones((n, 3))
+    P[:, 1:] = points
+    O = np.zeros((3, 3))
+    L = np.asarray(np.bmat([[K, P], [P.transpose(), O]]))
     return L
+
 
 def _calculate_f(coeffs, points, x, y):
     w = coeffs[:-3]
     a1, ax, ay = coeffs[-3:]
     # The following uses too much RAM:
-    # distances = _U(numpy.sqrt((points[:,0]-x[...,numpy.newaxis])**2 + (points[:,1]-y[...,numpy.newaxis])**2))
+    # distances = _U(np.sqrt((points[:,0]-x[...,np.newaxis])**2 +
+    # (points[:,1]-y[...,np.newaxis])**2))
     # summation = (w * distances).sum(axis=-1)
-    summation = numpy.zeros(x.shape)
+    summation = np.zeros(x.shape)
     for wi, Pi in zip(w, points):
-     summation += wi * _U(numpy.sqrt((x-Pi[0])**2 + (y-Pi[1])**2))
+        summation += wi * _U(np.sqrt((x-Pi[0])**2 + (y-Pi[1])**2))
     return a1 + ax*x + ay*y + summation
 
+
 def _make_warp(from_points, to_points, x_vals, y_vals):
-    from_points, to_points = numpy.asarray(from_points), numpy.asarray(to_points)
-    err = numpy.seterr(divide='ignore')
+    from_points = np.asarray(from_points)
+    to_points = np.asarray(to_points)
+    err = np.seterr(divide='ignore')
     L = _make_L_matrix(from_points)
-    V = numpy.resize(to_points, (len(to_points)+3, 2))
+    V = np.resize(to_points, (len(to_points)+3, 2))
     V[-3:, :] = 0
-    coeffs = numpy.dot(numpy.linalg.pinv(L), V)
-    x_warp = _calculate_f(coeffs[:,0], from_points, x_vals, y_vals)
-    y_warp = _calculate_f(coeffs[:,1], from_points, x_vals, y_vals)
-    numpy.seterr(**err)
+    coeffs = np.dot(np.linalg.pinv(L), V)
+    x_warp = _calculate_f(coeffs[:, 0], from_points, x_vals, y_vals)
+    y_warp = _calculate_f(coeffs[:, 1], from_points, x_vals, y_vals)
+    np.seterr(**err)
     return [x_warp, y_warp]


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description
Add `np` as `numpy` alias, sort import statements, fix pylint warnings

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
